### PR TITLE
Add HasHasManyThroughRelation Assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ composer require codenco-dev/eloquent-model-tester --dev
 
 ## Usage
 
-To use this package, you have to generate factories for your models. (See [Factories Documentation](https://laravel.com/docs/6.x/database-testing#writing-factories)) 
-You can generate one test file by model or for several. For your model `MyModel` you can use this command for example: 
+To use this package, you have to generate factories for your models. (See [Factories Documentation](https://laravel.com/docs/6.x/database-testing#writing-factories))
+You can generate one test file by model or for several. For your model `MyModel` you can use this command for example:
 
 ```bash
 php artisan make:model MyModel -mf
@@ -40,13 +40,13 @@ class MyModelTest extends TestCase
 {
     use RefreshDatabase;
     use HasModelTester;
-    
+
     public function test_have_my_model_model()
     {
         //...
     }
 }
-``` 
+```
 
 For more simplicity, you can put the `RefreshDatabase` use statement in `tests/TestCase.php` file
 
@@ -57,16 +57,15 @@ With this structure
     users
         id - integer
         name - string
-        other_field - string 
-   
+        other_field - string
 
 you can test if you have all the fields you need and if they are fillable.
 
-``` php
+```php
 class UserTest extends TestCase
 {
     use HasModelTestor;
-    
+
     public function test_have_user_model()
     {
         $this->modelTestable(User::class)
@@ -79,24 +78,24 @@ class UserTest extends TestCase
 ### HasMany et BelongsTo
 
 You can test relations of your models. For example, with this structure
-    
+
     categories
         id - integer
         name - string
-    
+
     customers
         id - integer
         name - string
         category_id - integer
         type_id - integer
 
-you can use `assertHasHasManyRelations` and `assertHasBelongsToRelations` methods  like this        
+you can use `assertHasHasManyRelations` and `assertHasBelongsToRelations` methods like this
 
-``` php
+```php
 class CategoryTest extends TestCase
-{ 
+{
     use HasModelTestor;
-    
+
     public function test_have_category_model()
     {
         $this->modelTestable(Category::class)
@@ -117,10 +116,10 @@ class CustomerTest extends TestCase
 }
 ```
 
-If you don't use Laravel naming convention, you may also override the relation and local keys (for belongsTo relation) by passing 
+If you don't use Laravel naming convention, you may also override the relation and local keys (for belongsTo relation) by passing
 additional arguments to the `assertHasHasManyRelations` and `assertHasBelongsToRelations` methods
 
-``` php
+```php
     $this->modelTestable(Customer::class)
             ->assertHasBelongsToRelation(Category::class,'category','category_id');
 
@@ -129,14 +128,54 @@ additional arguments to the `assertHasHasManyRelations` and `assertHasBelongsToR
 
 ```
 
-If you have several relations, you can chain methods like this: 
+If you have several relations, you can chain methods like this:
 
-``` php
+```php
 
     $this->modelTestable(Customer::class)
             ->assertHasBelongsToRelation(Category::class)
             ->assertHasBelongsToRelation(OtherModel::class);
-    
+
+```
+
+### HasManyThrough relations
+
+You can test has many through relations of your models. For example, with this structure
+
+    customers
+        id - integer
+        name - string
+
+    locations
+        id - integer
+        customer_id - integer
+
+    orders
+        id - integer
+        location_id - integer
+
+you can use `assertHasHasManyThroughRelations` method like this
+
+```php
+class CustomersTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_orders_model()
+    {
+        $this->modelTestable(Customer::class)
+            ->assertHasHasManyThroughRelation(Order::class, Location::class);
+    }
+
+}
+```
+
+If you don't use Laravel naming convention, you may also override the relation and foreign keys by passing additional arguments to the `assertHasHasManyThroughRelations` method
+
+```php
+    $this->modelTestable(Customer::class)
+            ->assertHasHasManyThroughRelation(Order::class, Location::class, 'sales', 'prefix_customer_id', 'prefix_location_id');
+
 ```
 
 ### Many to Many relations
@@ -155,13 +194,11 @@ You can test your ManyToMany relations with the `ManyToManyRelationsTestable` tr
         user_id - integer
         role_id - integer
 
-
-
 ```php
 class UserTest extends TestCase
 {
      use HasModelTestor;
-     
+
     public function test_have_user_model()
     {
         $this->modelTestable(User::class)
@@ -184,42 +221,41 @@ class RoleTest extends TestCase
 }
 ```
 
-You can override the relation argument too : 
+You can override the relation argument too :
+
 ```php
     $this->modelTestable(User::class)
             ->assertHasManyToManyRelation(User::class,'users');
 ```
-  
 
 ### Morph Relations
 
-If you have a Morph Relation, 
+If you have a Morph Relation,
 
     posts
         id - integer
         title - string
         body - text
-    
+
     videos
         id - integer
         title - string
         url - string
-    
+
     comments
         id - integer
         body - text
         commentable_id - integer
         commentable_type - string
 
-
 you can use `assertHasBelongsToMorphRelations` and `assertHasHasManyMorphRelations` methods like this
 
 ```php
 class PostTest extends TestCase
 {
-    
+
     use HasModelTestor;
-                
+
     public function test_have_post_model()
         {
             $this->modelTestable(Post::class)
@@ -230,7 +266,7 @@ class PostTest extends TestCase
 class VideoTest extends TestCase
 {
     use HasModelTestor;
-    
+
     public function test_have_video_model()
         {
             $this->modelTestable(Video::class)
@@ -240,9 +276,9 @@ class VideoTest extends TestCase
 
 class CommentTest extends TestCase
 {
-    
+
     use HasModelTestor;
-    
+
     public function test_have_morph_model_model()
     {
         $this->modelTestable(Comment::class)
@@ -254,7 +290,7 @@ class CommentTest extends TestCase
 
 ### Pivot and table without Model
 
-You can test if a table contains columns with the `tableTestable` method 
+You can test if a table contains columns with the `tableTestable` method
 
 ```php
 class MyPivotTest extends TestCase
@@ -269,7 +305,7 @@ class MyPivotTest extends TestCase
 
 ### Testing
 
-``` bash
+```bash
 composer test
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ If you don't use Laravel naming convention, you may also override the relation a
 
 ```php
     $this->modelTestable(Customer::class)
-            ->assertHasHasManyThroughRelation(Order::class, Location::class, 'sales', 'prefix_customer_id', 'prefix_location_id');
+            ->assertHasHasManyThroughRelation(Order::class, Location::class, 'sales', 'prefix_customer_id', 'prefix_location_id', 'firstPrimaryKey', 'secondPrimaryKey');
 
 ```
+
+_Attention_: as there is no **official** inverse of this relationship, it is not possible to use this assertion in the reverse, i.e., in the `orders` model checking for a `customers` relationship.
 
 ### Many to Many relations
 

--- a/database/factories/FifthModelFactory.php
+++ b/database/factories/FifthModelFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use CodencoDev\EloquentModelTester\Tests\TestModels\FifthModel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class FifthModelFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = FifthModel::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word,
+            'second_model_id' => null,
+        ];
+    }
+}

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -3,6 +3,7 @@
 namespace CodencoDev\EloquentModelTester\Tests;
 
 use CodencoDev\EloquentModelTester\HasModelTester;
+use CodencoDev\EloquentModelTester\Tests\TestModels\FifthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\FirstModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\FourthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\MorphModel;
@@ -21,7 +22,8 @@ class EloquentModelTest extends TestCase
         $this->modelTestable(FirstModel::class)
             ->assertHasColumns('id', 'name')
             ->assertCanFillables(['name'])
-            ->assertHasHasManyRelation(SecondModel::class);
+            ->assertHasHasManyRelation(SecondModel::class)
+            ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,6 +38,13 @@ abstract class TestCase extends Orchestra
             $table->string('name');
         });
 
+        $this->app['db']->connection()->getSchemaBuilder()->create('fifth_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('second_model_id')->nullable();
+            $table->foreign('second_model_id')->references('id')->on('second_models');
+        });
+
         $this->app['db']->connection()->getSchemaBuilder()->create('second_model_third_model', function (Blueprint $table) {
             $table->integer('second_model_id');
             $table->integer('third_model_id');

--- a/tests/TestModels/FifthModel.php
+++ b/tests/TestModels/FifthModel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CodencoDev\EloquentModelTester\Tests\TestModels;
+
+use Database\Factories\FifthModelFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FifthModel extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['id', 'name', 'second_model_id'];
+
+    public $timestamps = false;
+
+    protected static function newFactory()
+    {
+        return FifthModelFactory::new();
+    }
+}

--- a/tests/TestModels/FirstModel.php
+++ b/tests/TestModels/FirstModel.php
@@ -6,6 +6,7 @@ use Database\Factories\FirstModelFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class FirstModel extends Model
 {
@@ -18,6 +19,11 @@ class FirstModel extends Model
     public function second_models(): HasMany
     {
         return $this->hasMany(SecondModel::class, 'first_model_id', 'id');
+    }
+
+    public function fifth_models(): HasManyThrough
+    {
+        return $this->hasManyThrough(FifthModel::class, SecondModel::class, 'first_model_id', 'second_model_id');
     }
 
     protected static function newFactory()

--- a/tests/TestModels/SecondModel.php
+++ b/tests/TestModels/SecondModel.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class SecondModel extends Model
@@ -30,6 +31,11 @@ class SecondModel extends Model
     public function fourth_models(): BelongsToMany
     {
         return $this->belongsToMany(FourthModel::class, 'fourth_model_second_model', 'second_model_id', 'fourth_model_id')->withPivot(['pivot_field']);
+    }
+
+    public function fifth_models(): HasMany
+    {
+        return $this->hasMany(FifthModel::class, 'second_model_id', 'id');
     }
 
     public function morph_models(): MorphMany


### PR DESCRIPTION
I needed to test some HasManyThrough Relationships and thought I'd back feed this into the package.

The format of the function generally follows the order of the definition in the Model when creating the relationship.

I've extended the tests as I feel they should have, and updated the README file, but let me know if I've missed anything.