### PR TITLE
Fix issue with assertHasHasOneRelation and adding assertHasMorphOneRelation

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,64 @@ class CommentTest extends TestCase
 }
 ```
 
+#### MorphOne Relations
+If you have a Morph One Relation,
+
+    posts
+        id - integer
+        title - string
+        body - text
+
+    users
+        id - integer
+        title - string
+
+    images
+        id - integer
+        url - string
+        imageable_id - integer
+        imageable_type - string
+
+you can use `assertHasBelongsToMorphRelations` and `assertHasMorphOneRelations` methods like this
+
+```php
+class PostTest extends TestCase
+{
+
+    use HasModelTestor;
+
+    public function test_have_post_model()
+        {
+            $this->modelTestable(Post::class)
+                ->assertHasMorphOneRelation(Image::class,'images');
+        }
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_video_model()
+        {
+            $this->modelTestable(User::class)
+                ->assertHasMorphOneRelation(Image::class,'images');
+        }
+}
+
+class ImageTest extends TestCase
+{
+
+    use HasModelTestor;
+
+    public function test_have_morph_model_model()
+    {
+        $this->modelTestable(Image::class)
+           ->assertHasBelongsToMorphRelation(Post::class,'imageable')
+           ->assertHasBelongsToMorphRelation(User::class,'imageable');
+    }
+}
+```
+
 ### Pivot and table without Model
 
 You can test if a table contains columns with the `tableTestable` method

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ class PostTest extends TestCase
     public function test_have_post_model()
         {
             $this->modelTestable(Post::class)
-                ->assertHasMorphOneRelation(Image::class,'images');
+                ->assertHasMorphOneRelation(Image::class);
         }
 }
 
@@ -327,10 +327,10 @@ class UserTest extends TestCase
 {
     use HasModelTestor;
 
-    public function test_have_video_model()
+    public function test_have_user_model()
         {
             $this->modelTestable(User::class)
-                ->assertHasMorphOneRelation(Image::class,'images');
+                ->assertHasMorphOneRelation(Image::class, 'avatar');
         }
 }
 
@@ -339,7 +339,7 @@ class ImageTest extends TestCase
 
     use HasModelTestor;
 
-    public function test_have_morph_model_model()
+    public function test_have_image_model()
     {
         $this->modelTestable(Image::class)
            ->assertHasBelongsToMorphRelation(Post::class,'imageable')

--- a/database/factories/SixthModelFactory.php
+++ b/database/factories/SixthModelFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SixthModelFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SixthModel::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word(),
+            'first_model_id' => null,
+        ];
+    }
+}

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -150,6 +150,30 @@ class ModelTester extends TestCase
         return $this;
     }
 
+    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue= []): self
+    {
+        $modelInstance = $this->getModel()::factory()->create();
+
+        try {
+            $relatedInstance = $modelInstance->{$relation}()->save($related::factory()->make($defaultRelatedValue));
+            $modelInstance->refresh();
+            $relatedInstance->refresh();
+
+            $this->assertTrue($relatedInstance->is($modelInstance->{$relation}));
+            $this->assertEquals($relatedInstance->getAttributes(), $modelInstance->{$relation}->getAttributes());
+            $this->assertEquals(1, $modelInstance->{$relation}()->count());
+            $this->assertInstanceOf($related, $modelInstance->{$relation});
+        } catch (\Exception $e) {
+            $this->assertThat('Has Morph One Relation', self::isTrue(), sprintf(
+                'There is a problem with the MorphOneRelation %s : %s',
+                $relation,
+                $e->getMessage()
+            ));
+        }
+
+        return $this;
+    }
+
     public function assertHasHasManyRelation(string $related, ?string $relation = null, ?array $defaultRelatedValue = []): self
     {
         $relation = $relation ?: $this->getHasManyRelationName($related);

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -150,8 +150,10 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue = []): self
+    public function assertHasMorphOneRelation(string $related, ?string $relation, ?array $defaultRelatedValue = []): self
     {
+        $relation = $relation ?: $this->getHasOneRelationName($related);
+
         $modelInstance = $this->getModel()::factory()->create();
 
         try {

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -133,11 +133,12 @@ class ModelTester extends TestCase
         try {
             $relatedInstance = $modelInstance->{$relation}()->save($related::factory()->make($defaultRelatedValue));
             $modelInstance->refresh();
+            $relatedInstance->refresh();
 
-            $this->assertTrue($modelInstance->{$relation}->contains($relatedInstance));
-            $this->assertEquals(1, $modelInstance->{$relation}->count());
-            $this->assertInstanceOf(Collection::class, $modelInstance->{$relation});
-            $this->assertInstanceOf($related, $modelInstance->{$relation}->first());
+            $this->assertTrue($relatedInstance->is($modelInstance->{$relation}));
+            $this->assertEquals($relatedInstance->getAttributes(), $modelInstance->{$relation}->getAttributes());
+            $this->assertEquals(1, $modelInstance->{$relation}()->count());
+            $this->assertInstanceOf($related, $modelInstance->{$relation});
         } catch (\Exception $e) {
             $this->assertThat('Has Has One Relation', self::isTrue(), sprintf(
                 'There is a problem with the HasOneRelation %s : %s',

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -150,7 +150,7 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue= []): self
+    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue = []): self
     {
         $modelInstance = $this->getModel()::factory()->create();
 

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -8,6 +8,7 @@ use CodencoDev\EloquentModelTester\Tests\TestModels\FirstModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\FourthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\MorphModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\SecondModel;
+use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\ThirdModel;
 
 class EloquentModelTest extends TestCase
@@ -23,7 +24,8 @@ class EloquentModelTest extends TestCase
             ->assertHasColumns('id', 'name')
             ->assertCanFillables(['name'])
             ->assertHasHasManyRelation(SecondModel::class)
-            ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class);
+            ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class)
+            ->assertHasHasOneRelation(SixthModel::class);
     }
 
     /**
@@ -80,7 +82,22 @@ class EloquentModelTest extends TestCase
         $this->modelTestable(MorphModel::class)
             ->assertHasColumns(['id', 'name', 'morph_modelable_type', 'morph_modelable_id'])
             ->assertCanFillables(['name', 'morph_modelable_type', 'morph_modelable_id'])
-            ->assertHasBelongsToMorphRelation(SecondModel::class, 'morph_modelable');
+            ->assertHasBelongsToMorphRelation(SecondModel::class, 'morph_modelable')
+            ->assertHasBelongsToMorphRelation(SixthModel::class, 'morph_modelable');
+    }
+
+    /**
+     * @test
+     */
+    public function it_have_sixth_model_model()
+    {
+        $column = ['id', 'name', 'first_model_id'];
+        $this->modelTestable(SixthModel::class)
+            ->assertHasColumns($column)
+            ->assertCanFillables($column)
+            ->assertHasBelongsToRelation(FirstModel::class, 'first_model')
+            ->assertHasBelongsToRelation(FirstModel::class, 'first_model', 'first_model_id')
+            ->assertHasMorphOneRelation(MorphModel::class, 'morphed');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,6 +45,13 @@ abstract class TestCase extends Orchestra
             $table->foreign('second_model_id')->references('id')->on('second_models');
         });
 
+        $this->app['db']->connection()->getSchemaBuilder()->create('sixth_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('first_model_id')->nullable();
+            $table->foreign('first_model_id')->references('id')->on('first_models');
+        });
+
         $this->app['db']->connection()->getSchemaBuilder()->create('second_model_third_model', function (Blueprint $table) {
             $table->integer('second_model_id');
             $table->integer('third_model_id');

--- a/tests/TestModels/FirstModel.php
+++ b/tests/TestModels/FirstModel.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class FirstModel extends Model
 {
@@ -25,6 +26,11 @@ class FirstModel extends Model
     public function fifth_models(): HasManyThrough
     {
         return $this->hasManyThrough(FifthModel::class, SecondModel::class, 'first_model_id', 'second_model_id');
+    }
+
+    public function sixth_model(): HasOne
+    {
+        return $this->hasOne(SixthModel::class, 'first_model_id', 'id');
     }
 
     protected static function newFactory()

--- a/tests/TestModels/SixthModel.php
+++ b/tests/TestModels/SixthModel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CodencoDev\EloquentModelTester\Tests\TestModels;
+
+use Database\Factories\SixthModelFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class SixthModel extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = ['id', 'name', 'first_model_id'];
+
+    public function first_model(): BelongsTo
+    {
+        return $this->belongsTo(FirstModel::class, 'first_model_id', 'id');
+    }
+
+    public function morphed(): MorphOne
+    {
+        return $this->morphOne(MorphModel::class, 'morph_modelable');
+    }
+
+    protected static function newFactory()
+    {
+        return SixthModelFactory::new();
+    }
+}


### PR DESCRIPTION
I believe that there was an issue with the existing code that when using the assertion `assertHasHasOneRelation` it was expecting a collection to be retrieved from the relation. However, this is not the case. The relationship will return the related model.

Therefore the original asserts below would fail: https://github.com/codenco-dev/eloquent-model-tester/blob/c9f8565ea621059a871ecaa919c15a3c886c3df8/src/ModelTester.php#L137-L138

As such, I have corrected the code for the assertions of the `assertHasHasOneRelation` function, based on the answer [here](https://stackoverflow.com/a/49417655) on StackOverflow.

I have also expanded the assertions to include a `assertHasMorphOneRelation` which is very similar tot he `assertHasHasOneRelation` but requires a name for the relationship to be provided. This is because I don't think Laravel has a method of guessing the relationship name.

I also noticed that the test suite didn't include for any checks on the `assertHasHasOneRelation` and I have therefore expanded the test suite to include additional tests for both the `assertHasHasOneRelation` and the `assertHasMorphOneRelation`.

Let me know if there's anything else you need.