### PR TITLE
Add strict assertions for table columns, fillable and guarded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 .idea
 .phpunit.result*
+coverage/

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ With this structure
         name - string
         other_field - string
 
-you can test if you have all the fields you need and if they are fillable.
+you can test if you have all the fields you need and if they are fillable or guarded.
 
 ```php
 class UserTest extends TestCase
@@ -70,7 +70,25 @@ class UserTest extends TestCase
     {
         $this->modelTestable(User::class)
             ->assertHasColumns(['id','name','email','password','remember_token'])
-            ->assertCanFillables(['name','password']);
+            ->assertHasColumnsInFillable(['name','password'])
+            ->assertHasColumnsInGuarded(['remember_token']);
+    }
+}
+```
+
+The functions `assertHasColumnsInFillable()` and `assertHasColumnsInGuarded()` only check if the `$fillable` and `$guarded` arrays contain the values passed. If you want to ensure that no other entries are in the `$fillable` and `$guarded` arrays, then you can use the  stricter `assertHasOnlyColumnsInFillable()` and `assetHasOnlyColumnsInGuarded()` functions as follows:
+
+```php
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_user_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertHasColumns(['id','name','email','password','remember_token'])
+            ->assertHasOnlyColumnsInFillable(['name','password'])
+            ->assertHasOnlyColumnsInGuarded(['remember_token']);
     }
 }
 ```
@@ -378,6 +396,7 @@ class MyPivotTest extends TestCase
 | `assertHasOnlyColumnsInGuarded()`       | checks if the only the fields provided are those that appear in the $guarded array. ||
 | `assertHasNoGuardedAndFillableFields()` | checks that a column does not appear in both the $fillable and $guarded arrays.     ||
 | `assertHasHasOnRelation()`              | checks that the model has the `HasOne` relation.                                    ||
+| `assertHasMorphOneRelation()`           | checks that the model has the `MorphOne` relation.                                  ||
 | `assertHasHasManyRelation()`            | checks that the model hsa the `HasMany` relation.                                   ||
 | `assertHasHasManyThroughRelation()`     | checks that the model has the `HasManyThrough` relation.                            ||
 | `assertHasBelongsToRelation()`          | checks that the model has the `BelongsTo` relation.                                 ||

--- a/README.md
+++ b/README.md
@@ -290,6 +290,64 @@ class CommentTest extends TestCase
 }
 ```
 
+#### MorphOne Relations
+If you have a Morph One Relation,
+
+    posts
+        id - integer
+        title - string
+        body - text
+
+    users
+        id - integer
+        title - string
+
+    images
+        id - integer
+        url - string
+        imageable_id - integer
+        imageable_type - string
+
+you can use `assertHasBelongsToMorphRelations` and `assertHasMorphOneRelations` methods like this
+
+```php
+class PostTest extends TestCase
+{
+
+    use HasModelTestor;
+
+    public function test_have_post_model()
+        {
+            $this->modelTestable(Post::class)
+                ->assertHasMorphOneRelation(Image::class,'images');
+        }
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_video_model()
+        {
+            $this->modelTestable(User::class)
+                ->assertHasMorphOneRelation(Image::class,'images');
+        }
+}
+
+class ImageTest extends TestCase
+{
+
+    use HasModelTestor;
+
+    public function test_have_morph_model_model()
+    {
+        $this->modelTestable(Image::class)
+           ->assertHasBelongsToMorphRelation(Post::class,'imageable')
+           ->assertHasBelongsToMorphRelation(User::class,'imageable');
+    }
+}
+```
+
 ### Pivot and table without Model
 
 You can test if a table contains columns with the `tableTestable` method

--- a/README.md
+++ b/README.md
@@ -363,6 +363,29 @@ class MyPivotTest extends TestCase
 }
 ```
 
+### Available Assertions
+| Assertion                               | Description                                                                         | Notes                                                  |
+|-----------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------|
+| `assertHasTimestampsColumns()`          | checks if the `created_at` and `updated_at` columns are present in the table.       ||
+| `assertHasSoftDeleteTimestampColumns()` | checks if the `deleted_at` column is present in the table.                          ||
+| `assertHasColumns()`                    | checks for the presence of the provided column names appear in the table.           ||
+| `assertHasOnlyColumns()`                | checks that only the column names provided are the only columns of the table.       |
+| `assertCanOnlyFill()`                   | checks that only the fields provided can be filled and no others.                   |
+| `assertCanFillables()`                  | checks if the fields provided can be filled.                                        | *Deprecated* - Alias of `assertHasColumnsInFillable()` |
+| `assertHasColumnsInFillable()`          | checks if the fields provided can be filled.                                        ||
+| `assertHasOnlyColumnsInFillable()`      | checks if only the fields provided are those that appear in the $fillable array.    ||
+| `assertHasColumnsInGuarded()`           | checks if the fields provide are guarded.                                           ||
+| `assertHasOnlyColumnsInGuarded()`       | checks if the only the fields provided are those that appear in the $guarded array. ||
+| `assertHasNoGuardedAndFillableFields()` | checks that a column does not appear in both the $fillable and $guarded arrays.     ||
+| `assertHasHasOnRelation()`              | checks that the model has the `HasOne` relation.                                    ||
+| `assertHasHasManyRelation()`            | checks that the model hsa the `HasMany` relation.                                   ||
+| `assertHasHasManyThroughRelation()`     | checks that the model has the `HasManyThrough` relation.                            ||
+| `assertHasBelongsToRelation()`          | checks that the model has the `BelongsTo` relation.                                 ||
+| `assertHasManyToManyRelation()`         | checks that the model has the `ManyToMany` relation.                                ||
+| `assertHasHasManyMorphRelation()`       | checks that the model has the `HasManyMorph` relation.                              ||
+| `assertHasBelongsToMorphRelation()`     | checks that the model has the `BelongsToMorph` relation.                            ||
+| `assertHasScope()`                      | checks that the model has the scope.                                                ||
+
 ### Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -305,6 +305,29 @@ class MyPivotTest extends TestCase
 }
 ```
 
+### Available Assertions
+| Assertion                               | Description                                                                         | Notes                                                  |
+|-----------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------|
+| `assertHasTimestampsColumns()`          | checks if the `created_at` and `updated_at` columns are present in the table.       ||
+| `assertHasSoftDeleteTimestampColumns()` | checks if the `deleted_at` column is present in the table.                          ||
+| `assertHasColumns()`                    | checks for the presence of the provided column names appear in the table.           ||
+| `assertHasOnlyColumns()`                | checks that only the column names provided are the only columns of the table.       |
+| `assertCanOnlyFill()`                   | checks that only the fields provided can be filled and no others.                   |
+| `assertCanFillables()`                  | checks if the fields provided can be filled.                                        | *Deprecated* - Alias of `assertHasColumnsInFillable()` |
+| `assertHasColumnsInFillable()`          | checks if the fields provided can be filled.                                        ||
+| `assertHasOnlyColumnsInFillable()`      | checks if only the fields provided are those that appear in the $fillable array.    ||
+| `assertHasColumnsInGuarded()`           | checks if the fields provide are guarded.                                           ||
+| `assertHasOnlyColumnsInGuarded()`       | checks if the only the fields provided are those that appear in the $guarded array. ||
+| `assertHasNoGuardedAndFillableFields()` | checks that a column does not appear in both the $fillable and $guarded arrays.     ||
+| `assertHasHasOnRelation()`              | checks that the model has the `HasOne` relation.                                    ||
+| `assertHasHasManyRelation()`            | checks that the model hsa the `HasMany` relation.                                   ||
+| `assertHasHasManyThroughRelation()`     | checks that the model has the `HasManyThrough` relation.                            ||
+| `assertHasBelongsToRelation()`          | checks that the model has the `BelongsTo` relation.                                 ||
+| `assertHasManyToManyRelation()`         | checks that the model has the `ManyToMany` relation.                                ||
+| `assertHasHasManyMorphRelation()`       | checks that the model has the `HasManyMorph` relation.                              ||
+| `assertHasBelongsToMorphRelation()`     | checks that the model has the `BelongsToMorph` relation.                            ||
+| `assertHasScope()`                      | checks that the model has the scope.                                                ||
+
 ### Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ class PostTest extends TestCase
     public function test_have_post_model()
         {
             $this->modelTestable(Post::class)
-                ->assertHasMorphOneRelation(Image::class,'images');
+                ->assertHasMorphOneRelation(Image::class);
         }
 }
 
@@ -327,10 +327,10 @@ class UserTest extends TestCase
 {
     use HasModelTestor;
 
-    public function test_have_video_model()
+    public function test_have_user_model()
         {
             $this->modelTestable(User::class)
-                ->assertHasMorphOneRelation(Image::class,'images');
+                ->assertHasMorphOneRelation(Image::class, 'avatar');
         }
 }
 
@@ -339,7 +339,7 @@ class ImageTest extends TestCase
 
     use HasModelTestor;
 
-    public function test_have_morph_model_model()
+    public function test_have_image_model()
     {
         $this->modelTestable(Image::class)
            ->assertHasBelongsToMorphRelation(Post::class,'imageable')

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ composer require codenco-dev/eloquent-model-tester --dev
 
 ## Usage
 
-To use this package, you have to generate factories for your models. (See [Factories Documentation](https://laravel.com/docs/6.x/database-testing#writing-factories))
+To use this package, you have to generate factories for your models. (
+See [Factories Documentation](https://laravel.com/docs/6.x/database-testing#writing-factories))
 You can generate one test file by model or for several. For your model `MyModel` you can use this command for example:
 
 ```bash
@@ -50,14 +51,19 @@ class MyModelTest extends TestCase
 
 For more simplicity, you can put the `RefreshDatabase` use statement in `tests/TestCase.php` file
 
-### Test of structure and of fillable
+### Test of structure and of fillable / guarded
 
 With this structure
 
     users
         id - integer
         name - string
+        email - string
+        password - string
+        remeber_token - string
         other_field - string
+        created_at - timestamp
+        updated_at - timestamp
 
 you can test if you have all the fields you need and if they are fillable or guarded.
 
@@ -71,12 +77,23 @@ class UserTest extends TestCase
         $this->modelTestable(User::class)
             ->assertHasColumns(['id','name','email','password','remember_token'])
             ->assertHasColumnsInFillable(['name','password'])
-            ->assertHasColumnsInGuarded(['remember_token']);
+            ->assertHasColumnsInGuarded(['remember_token'])
+            ->assertHasTimestampsColumns();
     }
 }
 ```
 
-The functions `assertHasColumnsInFillable()` and `assertHasColumnsInGuarded()` only check if the `$fillable` and `$guarded` arrays contain the values passed. If you want to ensure that no other entries are in the `$fillable` and `$guarded` arrays, then you can use the  stricter `assertHasOnlyColumnsInFillable()` and `assetHasOnlyColumnsInGuarded()` functions as follows:
+The function `assertHasColumns()` only checks if the values provided are in the schema of the table. If you want to
+ensure that no other columns are present, you can use the stricter `assertHasOnlyColumns()` assertion to check that *
+only* the column names provided are present in the table.
+
+***N.B. When using this you will need to provide the `created_at` and `updated_at` fields if they are present in the
+database table.***
+
+The functions `assertHasColumnsInFillable()` and `assertHasColumnsInGuarded()` only check if the `$fillable`
+and `$guarded` arrays contain the values passed. If you want to ensure that no other entries are in the `$fillable`
+and `$guarded` arrays, then you can use the stricter `assertHasOnlyColumnsInFillable()`
+and `assetHasOnlyColumnsInGuarded()` functions as follows:
 
 ```php
 class UserTest extends TestCase
@@ -86,9 +103,125 @@ class UserTest extends TestCase
     public function test_have_user_model()
     {
         $this->modelTestable(User::class)
-            ->assertHasColumns(['id','name','email','password','remember_token'])
+            ->assertHasOnlyColumns(['id','name','email','password','remember_token', 'created_at', 'updated_at']) // Will fail as missing 'other_field'.
             ->assertHasOnlyColumnsInFillable(['name','password'])
             ->assertHasOnlyColumnsInGuarded(['remember_token']);
+    }
+}
+```
+
+To further confirm that only a set of columns can be filled, you can use the `assertCanOnlyFill()` assertion to confirm
+this. This assertion confirms that the fields provided are the only columns that can be filled, by confirming that these
+are the only values in the `$fillable` array and they don't appear in the `$guarded` array.
+
+```php
+class User extends Model
+{
+    $fillable = ['name', 'password', 'email'];
+    
+    $guarded = ['remember_token'];
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_user_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertHasColumns(['id','name','email','password','remember_token'])
+            ->assertCanOnlyFill(['name','password']); // Will fail as 'email' is in the fillable array.
+    }
+}
+```
+
+To confirm that a field does not appear in both the `$fillable` and `$guarded` arrays by mistake there is
+the `assertNoGuardedAndFillableFields()` assertion that checks that no entry appears in both:
+
+```php
+class User extends Model
+{
+    $fillable = ['name', 'password', 'email'];
+    
+    $guarded = ['email'];
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_user_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertNoGuardedAndFillableFields(); // Will fail as 'email' is in both the fillable & guarded arrays.
+    }
+}
+```
+
+To check for soft delete `deleted_at` column on your model, you can use the `assertHasSoftDeleteTimestampColumns()`
+assertion:
+
+    user:
+        id - integer
+        name - string
+        deleted_at - timestamp
+
+```php
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class User extends Model
+{
+    use SoftDeletes;
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_user_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertHasSoftDeleteTimestampColumns();
+    }
+}
+```
+
+### HasOne et BelongsTo
+
+You can test relations of your models. For example, with this structure
+
+    user
+        id - integer
+        name - string
+
+    phones
+        id - integer
+        number - string
+        user_id - integer
+
+you can use `assertHasOneRelation()` and `assertHasBelongsToRelations` methods like this:
+
+```php
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_category_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertHasOneRelation(Phone::class);
+    }
+
+}
+
+class PhoneTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_customer_model()
+    {
+        $this->modelTestable(Phone::class)
+            ->assertHasBelongsToRelation(User::class);
     }
 }
 ```
@@ -134,7 +267,8 @@ class CustomerTest extends TestCase
 }
 ```
 
-If you don't use Laravel naming convention, you may also override the relation and local keys (for belongsTo relation) by passing
+If you don't use Laravel naming convention, you may also override the relation and local keys (for belongsTo relation)
+by passing
 additional arguments to the `assertHasHasManyRelations` and `assertHasBelongsToRelations` methods
 
 ```php
@@ -188,7 +322,8 @@ class CustomersTest extends TestCase
 }
 ```
 
-If you don't use Laravel naming convention, you may also override the relation and foreign keys by passing additional arguments to the `assertHasHasManyThroughRelations` method
+If you don't use Laravel naming convention, you may also override the relation and foreign keys by passing additional
+arguments to the `assertHasHasManyThroughRelations` method
 
 ```php
     $this->modelTestable(Customer::class)
@@ -196,7 +331,8 @@ If you don't use Laravel naming convention, you may also override the relation a
 
 ```
 
-_Attention_: as there is no **official** inverse of this relationship, it is not possible to use this assertion in the reverse, i.e., in the `orders` model checking for a `customers` relationship.
+_Attention_: as there is no **official** inverse of this relationship, it is not possible to use this assertion in the
+reverse, i.e., in the `orders` model checking for a `customers` relationship.
 
 ### Many to Many relations
 
@@ -309,6 +445,7 @@ class CommentTest extends TestCase
 ```
 
 #### MorphOne Relations
+
 If you have a Morph One Relation,
 
     posts
@@ -381,7 +518,70 @@ class MyPivotTest extends TestCase
 }
 ```
 
+### Model Scopes
+
+You can test if a model has a query scope defined using the `assertHasScope()` assertion:
+
+```php
+class User extends Model
+{
+    /**
+     * Scope a query to only include popular users.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopePopular($query)
+    {
+        return $query->where('votes', '>', 100);
+    }
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_user_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertHasScope('popular');
+    }
+}
+
+```
+
+Of course if you're using Dynamic Scopes then `assertHasScope()` takes the arguments to pass to the query scope:
+
+```php
+class User extends Model
+{
+    /**
+    * Scope a query to only include users of a given type.
+    *
+    * @param  \Illuminate\Database\Eloquent\Builder  $query
+    * @param  mixed  $type
+    * @return \Illuminate\Database\Eloquent\Builder
+    */
+    public function scopeOfType($query, $type)
+    {
+        return $query->where('type', $type);
+    }
+}
+
+class UserTest extends TestCase
+{
+    use HasModelTestor;
+
+    public function test_have_user_model()
+    {
+        $this->modelTestable(User::class)
+            ->assertHasScope('ofType', 'admin');
+    }
+}
+```
+
 ### Available Assertions
+
 | Assertion                               | Description                                                                         | Notes                                                  |
 |-----------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------|
 | `assertHasTimestampsColumns()`          | checks if the `created_at` and `updated_at` columns are present in the table.       ||
@@ -389,13 +589,14 @@ class MyPivotTest extends TestCase
 | `assertHasColumns()`                    | checks for the presence of the provided column names appear in the table.           ||
 | `assertHasOnlyColumns()`                | checks that only the column names provided are the only columns of the table.       |
 | `assertCanOnlyFill()`                   | checks that only the fields provided can be filled and no others.                   |
-| `assertCanFillables()`                  | checks if the fields provided can be filled.                                        | *Deprecated* - Alias of `assertHasColumnsInFillable()` |
+| `assertCanFillables()`                  | checks if the fields provided can be filled.                                        | *
+Deprecated* - Alias of `assertHasColumnsInFillable()` |
 | `assertHasColumnsInFillable()`          | checks if the fields provided can be filled.                                        ||
 | `assertHasOnlyColumnsInFillable()`      | checks if only the fields provided are those that appear in the $fillable array.    ||
 | `assertHasColumnsInGuarded()`           | checks if the fields provide are guarded.                                           ||
 | `assertHasOnlyColumnsInGuarded()`       | checks if the only the fields provided are those that appear in the $guarded array. ||
 | `assertHasNoGuardedAndFillableFields()` | checks that a column does not appear in both the $fillable and $guarded arrays.     ||
-| `assertHasHasOnRelation()`              | checks that the model has the `HasOne` relation.                                    ||
+| `assertHasHasOneRelation()`             | checks that the model has the `HasOne` relation.                                    ||
 | `assertHasMorphOneRelation()`           | checks that the model has the `MorphOne` relation.                                  ||
 | `assertHasHasManyRelation()`            | checks that the model hsa the `HasMany` relation.                                   ||
 | `assertHasHasManyThroughRelation()`     | checks that the model has the `HasManyThrough` relation.                            ||

--- a/database/factories/FifthModelFactory.php
+++ b/database/factories/FifthModelFactory.php
@@ -24,7 +24,7 @@ class FifthModelFactory extends Factory
         return [
             'name' => $this->faker->word,
             'second_model_id' => null,
-            'isAdmin' => $this->faker->boolean,
+            'is_admin' => $this->faker->boolean,
         ];
     }
 }

--- a/database/factories/FifthModelFactory.php
+++ b/database/factories/FifthModelFactory.php
@@ -24,6 +24,7 @@ class FifthModelFactory extends Factory
         return [
             'name' => $this->faker->word,
             'second_model_id' => null,
+            'isAdmin' => $this->faker->boolean,
         ];
     }
 }

--- a/database/factories/SixthModelFactory.php
+++ b/database/factories/SixthModelFactory.php
@@ -2,17 +2,17 @@
 
 namespace Database\Factories;
 
-use CodencoDev\EloquentModelTester\Tests\TestModels\FifthModel;
+use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-class FifthModelFactory extends Factory
+class SixthModelFactory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      *
      * @var string
      */
-    protected $model = FifthModel::class;
+    protected $model = SixthModel::class;
 
     /**
      * Define the model's default state.
@@ -23,7 +23,6 @@ class FifthModelFactory extends Factory
     {
         return [
             'name' => $this->faker->word,
-            'second_model_id' => null,
             'isAdmin' => $this->faker->boolean,
         ];
     }

--- a/database/factories/SixthModelFactory.php
+++ b/database/factories/SixthModelFactory.php
@@ -24,7 +24,7 @@ class SixthModelFactory extends Factory
         return [
             'name' => $this->faker->word,
             'first_model_id' => null,
-            'isAdmin' => $this->faker->boolean,
+            'is_admin' => $this->faker->boolean,
         ];
     }
 }

--- a/database/factories/SixthModelFactory.php
+++ b/database/factories/SixthModelFactory.php
@@ -22,8 +22,9 @@ class SixthModelFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->word(),
+            'name' => $this->faker->word,
             'first_model_id' => null,
+            'isAdmin' => $this->faker->boolean,
         ];
     }
 }

--- a/database/factories/SixthModelFactory.php
+++ b/database/factories/SixthModelFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SixthModelFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SixthModel::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word(),
+            'first_model_id' => null,
+        ];
+    }
+}

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -154,7 +154,8 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasOnlyColumnsInFillable(array|string ...$columns):self {
+    public function assertHasOnlyColumnsInFillable(array|string ...$columns):self
+    {
         $columns = $this->getArrayParameters(...$columns);
         $modelClass = $this->getModel();
         $modelObject = new $modelClass;

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -122,6 +122,7 @@ class ModelTester extends TestCase
 
         $this->assertHasNoGuardedAndFillableFields();
         $this->assertEqualsCanonicalizing($columns, $diff, 'The expected fillable fields differ from those defined in $fillable and $guarded.');
+        $this->assertCanFillables($diff);
 
         return $this;
     }

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -150,6 +150,30 @@ class ModelTester extends TestCase
         return $this;
     }
 
+    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue= []): self
+    {
+        $modelInstance = $this->getModel()::factory()->create();
+
+        try {
+            $relatedInstance = $modelInstance->{$relation}()->save($related::factory()->make($defaultRelatedValue));
+            $modelInstance->refresh();
+            $relatedInstance->refresh();
+
+            $this->assertTrue($relatedInstance->is($modelInstance->{$relation}));
+            $this->assertEquals($relatedInstance->getAttributes(), $modelInstance->{$relation}->getAttributes());
+            $this->assertEquals(1, $modelInstance->{$relation}()->count());
+            $this->assertInstanceOf($related, $modelInstance->{$relation});
+        } catch (\Exception $e) {
+            $this->assertThat('Has Morph One Relation', self::isTrue(), sprintf(
+                'There is a problem with the MorphOneRelation %s : %s',
+                $relation,
+                $e->getMessage()
+            ));
+        }
+
+        return $this;
+    }
+
     public function assertHasHasManyRelation(string $related, ?string $relation = null, ?array $defaultRelatedValue = []): self
     {
         $relation = $relation ?: $this->getHasManyRelationName($related);

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -206,7 +206,7 @@ class ModelTester extends TestCase
         $fillable = $modelObject->getFillable();
         $guarded = $modelObject->getGuarded();
 
-        $intersect = array_intersect($fillable, $guarded);
+        $intersect = collect(array_intersect($fillable, $guarded));
 
         $this->assertEquals(
             [],

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -150,8 +150,10 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue = []): self
+    public function assertHasMorphOneRelation(string $related, ?string $relation, ?array $defaultRelatedValue = []): self
     {
+        $relation = $relation ?: $this->getHasOneRelationName($related);
+
         $modelInstance = $this->getModel()::factory()->create();
 
         try {

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -133,11 +133,12 @@ class ModelTester extends TestCase
         try {
             $relatedInstance = $modelInstance->{$relation}()->save($related::factory()->make($defaultRelatedValue));
             $modelInstance->refresh();
+            $relatedInstance->refresh();
 
-            $this->assertTrue($modelInstance->{$relation}->contains($relatedInstance));
-            $this->assertEquals(1, $modelInstance->{$relation}->count());
-            $this->assertInstanceOf(Collection::class, $modelInstance->{$relation});
-            $this->assertInstanceOf($related, $modelInstance->{$relation}->first());
+            $this->assertTrue($relatedInstance->is($modelInstance->{$relation}));
+            $this->assertEquals($relatedInstance->getAttributes(), $modelInstance->{$relation}->getAttributes());
+            $this->assertEquals(1, $modelInstance->{$relation}()->count());
+            $this->assertInstanceOf($related, $modelInstance->{$relation});
         } catch (\Exception $e) {
             $this->assertThat('Has Has One Relation', self::isTrue(), sprintf(
                 'There is a problem with the HasOneRelation %s : %s',

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -150,7 +150,7 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue= []): self
+    public function assertHasMorphOneRelation(string $related, string $relation, ?array $defaultRelatedValue = []): self
     {
         $modelInstance = $this->getModel()::factory()->create();
 

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -127,6 +127,9 @@ class ModelTester extends TestCase
         return $this;
     }
 
+    /**
+     * @deprecated
+     */
     public function assertCanFillables(array|string ...$columns): self
     {
         return $this->assertHasColumnsInFillable(...$columns);

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -101,7 +101,37 @@ class ModelTester extends TestCase
         return $this;
     }
 
+    public function assertHasOnlyColumns(array|string ...$columns): self
+    {
+        $columns = $this->getArrayParameters(...$columns);
+        $this->assertEqualsCanonicalizing($columns, Schema::getColumnListing($this->getTable()), 'The columns of the database table do not match the expected values.');
+
+        return $this;
+    }
+
+    public function assertCanOnlyFill(array|string ...$columns): self
+    {
+        $columns = $this->getArrayParameters(...$columns);
+        $modelClass = $this->getModel();
+        $modelObject = new $modelClass;
+
+        $fillable = $modelObject->getFillable();
+        $guarded = $modelObject->getGuarded();
+
+        $diff = array_diff($fillable, $guarded);
+
+        $this->assertHasNoGuardedAndFillableFields();
+        $this->assertEqualsCanonicalizing($columns, $diff, 'The expected fillable fields differ from those defined in $fillable and $guarded.');
+
+        return $this;
+    }
+
     public function assertCanFillables(array|string ...$columns): self
+    {
+        return $this->assertHasColumnsInFillable(...$columns);
+    }
+
+    public function assertHasColumnsInFillable(array|string ...$columns): self
     {
         $columns = $this->getArrayParameters(...$columns);
         $modelClass = $this->getModel();
@@ -118,6 +148,72 @@ class ModelTester extends TestCase
             sprintf(
                 'Column %s isn\'t mass fillable.',
                 $notFillable->implode(', ')
+            )
+        );
+
+        return $this;
+    }
+
+    public function assertHasOnlyColumnsInFillable(array|string ...$columns):self {
+        $columns = $this->getArrayParameters(...$columns);
+        $modelClass = $this->getModel();
+        $modelObject = new $modelClass;
+
+        $this->assertEqualsCanonicalizing($columns, $modelObject->getFillable(), 'Model $fillable array does not match expected.');
+
+        return $this;
+    }
+
+    public function assertHasColumnsInGuarded(array|string ...$columns): self
+    {
+        $columns = $this->getArrayParameters(...$columns);
+        $modelClass = $this->getModel();
+        $modelObject = new $modelClass;
+        $notGuarded = collect([]);
+        foreach ($columns as $column) {
+            if (! $modelObject->isGuarded($column)) {
+                $notGuarded->push($column);
+            }
+        }
+        $this->assertEquals(
+            [],
+            $notGuarded->toArray(),
+            sprintf(
+                'Column %s isn\'t guarded.',
+                $notGuarded->implode(', ')
+            )
+        );
+
+        return $this;
+    }
+
+    public function assertHasOnlyColumnsInGuarded(array|string ...$columns):self
+    {
+        $columns = $this->getArrayParameters(...$columns);
+        $modelClass = $this->getModel();
+        $modelObject = new $modelClass;
+
+        $this->assertEqualsCanonicalizing($columns, $modelObject->getGuarded());
+
+        return $this;
+    }
+
+    public function assertHasNoGuardedAndFillableFields(): self
+    {
+        $modelClass = $this->getModel();
+        $modelObject = new $modelClass;
+
+        $fillable = $modelObject->getFillable();
+        $guarded = $modelObject->getGuarded();
+
+        $intersect = array_intersect($fillable, $guarded);
+
+        $this->assertEquals(
+            [],
+            $intersect->toArray(),
+            sprintf(
+                'Column %s appear in guarded and fillable.',
+                $intersect->implode(', ')
             )
         );
 

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -154,7 +154,7 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasOnlyColumnsInFillable(array|string ...$columns):self
+    public function assertHasOnlyColumnsInFillable(array|string ...$columns): self
     {
         $columns = $this->getArrayParameters(...$columns);
         $modelClass = $this->getModel();
@@ -188,7 +188,7 @@ class ModelTester extends TestCase
         return $this;
     }
 
-    public function assertHasOnlyColumnsInGuarded(array|string ...$columns):self
+    public function assertHasOnlyColumnsInGuarded(array|string ...$columns): self
     {
         $columns = $this->getArrayParameters(...$columns);
         $modelClass = $this->getModel();

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -27,7 +27,7 @@ class EloquentModelTest extends TestCase
             ->assertCanFillables(['name'])
             ->assertHasOnlyColumnsInFillable(['id', 'name'])
             ->assertHasNoGuardedAndFillableFields()
-            ->assertCanOnlyFill(['id','name'])
+            ->assertCanOnlyFill(['id', 'name'])
             ->assertHasHasManyRelation(SecondModel::class)
             ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class);
     }

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -27,7 +27,7 @@ class EloquentModelTest extends TestCase
             ->assertCanFillables(['name'])
             ->assertHasOnlyColumnsInFillable(['id', 'name'])
             ->assertHasNoGuardedAndFillableFields()
-            ->assertCanOnlyFill(['id','name'])
+            ->assertCanOnlyFill(['id', 'name'])
             ->assertHasHasManyRelation(SecondModel::class)
             ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class)
             ->assertHasHasOneRelation(SixthModel::class);

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -109,7 +109,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertCanOnlyFill(['id', 'name','second_model_id', 'isAdmin']);
+            ->assertCanOnlyFill(['id', 'name', 'second_model_id', 'isAdmin']);
     }
 
     /**
@@ -119,7 +119,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertHasOnlyColumns(['id', 'name','second_model_id', 'isAdmin', 'missing']);
+            ->assertHasOnlyColumns(['id', 'name', 'second_model_id', 'isAdmin', 'missing']);
     }
 
     /**
@@ -169,7 +169,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(SixthModel::class)
-            ->assertCanOnlyFill('id','name','isAdmin');
+            ->assertCanOnlyFill('id', 'name', 'isAdmin');
     }
 
     /**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -8,7 +8,9 @@ use CodencoDev\EloquentModelTester\Tests\TestModels\FirstModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\FourthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\MorphModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\SecondModel;
+use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\ThirdModel;
+use PHPUnit\Framework\ExpectationFailedException;
 
 class EloquentModelTest extends TestCase
 {
@@ -21,7 +23,11 @@ class EloquentModelTest extends TestCase
     {
         $this->modelTestable(FirstModel::class)
             ->assertHasColumns('id', 'name')
+            ->assertHasOnlyColumns('id', 'name')
             ->assertCanFillables(['name'])
+            ->assertHasOnlyColumnsInFillable(['id', 'name'])
+            ->assertHasNoGuardedAndFillableFields()
+            ->assertCanOnlyFill(['id','name'])
             ->assertHasHasManyRelation(SecondModel::class)
             ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class);
     }
@@ -70,6 +76,99 @@ class EloquentModelTest extends TestCase
             ->assertHasColumns(['id', 'name'])
             ->assertCanFillables(['name'])
             ->assertHasManyToManyRelation(SecondModel::class, 'second_models');
+    }
+
+    /**
+     * @test
+     */
+    public function it_have_fifth_model_model()
+    {
+        $this->modelTestable(FifthModel::class)
+            ->assertHasColumns(['id', 'name'])
+            ->assertCanFillables(['name'])
+            ->assertHasColumnsInGuarded('isAdmin')
+            ->assertHasOnlyColumnsInGuarded('isAdmin');
+    }
+
+    /**
+     * @test
+     */
+    public function it_tests_for_the_timestamps()
+    {
+        $this->modelTestable(SixthModel::class)
+            ->assertHasColumns(['id', 'name'])
+            ->assertHasTimestampsColumns()
+            ->assertHasSoftDeleteTimestampColumns();
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_fillable_field_is_not_exactly_as_expected()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertCanOnlyFill(['id', 'name','second_model_id', 'isAdmin']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_table_columns_is_not_exactly_as_expected()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasOnlyColumns(['id', 'name','second_model_id', 'isAdmin', 'missing']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_field_is_not_exactly_as_expected()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasOnlyColumnsInGuarded(['id', 'isAdmin']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_field_does_not_include_the_expected_value()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasColumnsInGuarded(['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_fillable_field_does_not_include_the_expected_value()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasColumnsInFillable(['isAdmin']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_and_fillable_arrays_contain_the_same_value()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(SixthModel::class)
+            ->assertHasNoGuardedAndFillableFields();
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_and_fillable_arrays_contain_the_same_value_when_asserting_only_fillable()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(SixthModel::class)
+            ->assertCanOnlyFill('id','name','isAdmin');
     }
 
     /**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -88,8 +88,8 @@ class EloquentModelTest extends TestCase
             ->assertHasColumns(['id', 'name'])
             ->assertCanFillables(['name'])
             ->assertCanOnlyFill('name', 'id', 'second_model_id')
-            ->assertHasColumnsInGuarded('isAdmin')
-            ->assertHasOnlyColumnsInGuarded('isAdmin');
+            ->assertHasColumnsInGuarded('is_admin')
+            ->assertHasOnlyColumnsInGuarded('is_admin');
     }
 
     /**
@@ -110,7 +110,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertCanOnlyFill(['id', 'name', 'second_model_id', 'isAdmin']);
+            ->assertCanOnlyFill(['id', 'name', 'second_model_id', 'is_admin']);
     }
 
     /**
@@ -120,7 +120,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertHasOnlyColumns(['id', 'name', 'second_model_id', 'isAdmin', 'missing']);
+            ->assertHasOnlyColumns(['id', 'name', 'second_model_id', 'is_admin', 'missing']);
     }
 
     /**
@@ -130,7 +130,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertHasOnlyColumnsInGuarded(['id', 'isAdmin']);
+            ->assertHasOnlyColumnsInGuarded(['id', 'is_admin']);
     }
 
     /**
@@ -150,7 +150,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertHasColumnsInFillable(['isAdmin']);
+            ->assertHasColumnsInFillable(['is_admin']);
     }
 
     /**
@@ -170,7 +170,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(SixthModel::class)
-            ->assertCanOnlyFill('id', 'name', 'isAdmin');
+            ->assertCanOnlyFill('id', 'name', 'is_admin');
     }
 
     /**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -87,6 +87,7 @@ class EloquentModelTest extends TestCase
         $this->modelTestable(FifthModel::class)
             ->assertHasColumns(['id', 'name'])
             ->assertCanFillables(['name'])
+            ->assertCanOnlyFill('name', 'id', 'second_model_id')
             ->assertHasColumnsInGuarded('isAdmin')
             ->assertHasOnlyColumnsInGuarded('isAdmin');
     }

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -86,6 +86,7 @@ class EloquentModelTest extends TestCase
         $this->modelTestable(FifthModel::class)
             ->assertHasColumns(['id', 'name'])
             ->assertCanFillables(['name'])
+            ->assertCanOnlyFill('name', 'id', 'second_model_id')
             ->assertHasColumnsInGuarded('isAdmin')
             ->assertHasOnlyColumnsInGuarded('isAdmin');
     }

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -8,6 +8,7 @@ use CodencoDev\EloquentModelTester\Tests\TestModels\FirstModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\FourthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\MorphModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\SecondModel;
+use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\ThirdModel;
 
 class EloquentModelTest extends TestCase
@@ -23,7 +24,8 @@ class EloquentModelTest extends TestCase
             ->assertHasColumns('id', 'name')
             ->assertCanFillables(['name'])
             ->assertHasHasManyRelation(SecondModel::class)
-            ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class);
+            ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class)
+            ->assertHasHasOneRelation(SixthModel::class);
     }
 
     /**
@@ -80,7 +82,22 @@ class EloquentModelTest extends TestCase
         $this->modelTestable(MorphModel::class)
             ->assertHasColumns(['id', 'name', 'morph_modelable_type', 'morph_modelable_id'])
             ->assertCanFillables(['name', 'morph_modelable_type', 'morph_modelable_id'])
-            ->assertHasBelongsToMorphRelation(SecondModel::class, 'morph_modelable');
+            ->assertHasBelongsToMorphRelation(SecondModel::class, 'morph_modelable')
+            ->assertHasBelongsToMorphRelation(SixthModel::class, 'morph_modelable');
+    }
+
+    /**
+     * @test
+     */
+    public function it_have_sixth_model_model()
+    {
+        $column = ['id', 'name', 'first_model_id'];
+        $this->modelTestable(SixthModel::class)
+            ->assertHasColumns($column)
+            ->assertCanFillables($column)
+            ->assertHasBelongsToRelation(FirstModel::class, 'first_model')
+            ->assertHasBelongsToRelation(FirstModel::class, 'first_model', 'first_model_id')
+            ->assertHasMorphOneRelation(MorphModel::class, 'morphed');
     }
 
     /**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -10,6 +10,7 @@ use CodencoDev\EloquentModelTester\Tests\TestModels\MorphModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\SecondModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\SixthModel;
 use CodencoDev\EloquentModelTester\Tests\TestModels\ThirdModel;
+use PHPUnit\Framework\ExpectationFailedException;
 
 class EloquentModelTest extends TestCase
 {
@@ -22,7 +23,11 @@ class EloquentModelTest extends TestCase
     {
         $this->modelTestable(FirstModel::class)
             ->assertHasColumns('id', 'name')
+            ->assertHasOnlyColumns('id', 'name')
             ->assertCanFillables(['name'])
+            ->assertHasOnlyColumnsInFillable(['id', 'name'])
+            ->assertHasNoGuardedAndFillableFields()
+            ->assertCanOnlyFill(['id','name'])
             ->assertHasHasManyRelation(SecondModel::class)
             ->assertHasHasManyThroughRelation(FifthModel::class, SecondModel::class)
             ->assertHasHasOneRelation(SixthModel::class);
@@ -72,6 +77,99 @@ class EloquentModelTest extends TestCase
             ->assertHasColumns(['id', 'name'])
             ->assertCanFillables(['name'])
             ->assertHasManyToManyRelation(SecondModel::class, 'second_models');
+    }
+
+    /**
+     * @test
+     */
+    public function it_have_fifth_model_model()
+    {
+        $this->modelTestable(FifthModel::class)
+            ->assertHasColumns(['id', 'name'])
+            ->assertCanFillables(['name'])
+            ->assertHasColumnsInGuarded('isAdmin')
+            ->assertHasOnlyColumnsInGuarded('isAdmin');
+    }
+
+    /**
+     * @test
+     */
+    public function it_tests_for_the_timestamps()
+    {
+        $this->modelTestable(SixthModel::class)
+            ->assertHasColumns(['id', 'name'])
+            ->assertHasTimestampsColumns()
+            ->assertHasSoftDeleteTimestampColumns();
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_fillable_field_is_not_exactly_as_expected()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertCanOnlyFill(['id', 'name','second_model_id', 'isAdmin']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_table_columns_is_not_exactly_as_expected()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasOnlyColumns(['id', 'name','second_model_id', 'isAdmin', 'missing']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_field_is_not_exactly_as_expected()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasOnlyColumnsInGuarded(['id', 'isAdmin']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_field_does_not_include_the_expected_value()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasColumnsInGuarded(['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_fillable_field_does_not_include_the_expected_value()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(FifthModel::class)
+            ->assertHasColumnsInFillable(['isAdmin']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_and_fillable_arrays_contain_the_same_value()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(SixthModel::class)
+            ->assertHasNoGuardedAndFillableFields();
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_when_the_guarded_and_fillable_arrays_contain_the_same_value_when_asserting_only_fillable()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->modelTestable(SixthModel::class)
+            ->assertCanOnlyFill('id','name','isAdmin');
     }
 
     /**

--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -108,7 +108,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertCanOnlyFill(['id', 'name','second_model_id', 'isAdmin']);
+            ->assertCanOnlyFill(['id', 'name', 'second_model_id', 'isAdmin']);
     }
 
     /**
@@ -118,7 +118,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(FifthModel::class)
-            ->assertHasOnlyColumns(['id', 'name','second_model_id', 'isAdmin', 'missing']);
+            ->assertHasOnlyColumns(['id', 'name', 'second_model_id', 'isAdmin', 'missing']);
     }
 
     /**
@@ -168,7 +168,7 @@ class EloquentModelTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
         $this->modelTestable(SixthModel::class)
-            ->assertCanOnlyFill('id','name','isAdmin');
+            ->assertCanOnlyFill('id', 'name', 'isAdmin');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,14 +42,14 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('name');
             $table->integer('second_model_id')->nullable();
-            $table->boolean('isAdmin')->default(false);
+            $table->boolean('is_admin')->default(false);
             $table->foreign('second_model_id')->references('id')->on('second_models');
         });
 
         $this->app['db']->connection()->getSchemaBuilder()->create('sixth_models', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->boolean('isAdmin')->default(false);
+            $table->boolean('is_admin')->default(false);
             $table->integer('first_model_id')->nullable();
             $table->foreign('first_model_id')->references('id')->on('first_models');
             $table->timestamps();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,16 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('name');
             $table->integer('second_model_id')->nullable();
+            $table->boolean('isAdmin')->default(false);
             $table->foreign('second_model_id')->references('id')->on('second_models');
+        });
+
+        $this->app['db']->connection()->getSchemaBuilder()->create('sixth_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->boolean('isAdmin')->default(false);
+            $table->timestamps();
+            $table->softDeletes();
         });
 
         $this->app['db']->connection()->getSchemaBuilder()->create('second_model_third_model', function (Blueprint $table) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,6 +45,13 @@ abstract class TestCase extends Orchestra
             $table->foreign('second_model_id')->references('id')->on('second_models');
         });
 
+        $this->app['db']->connection()->getSchemaBuilder()->create('sixth_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->integer('first_model_id')->nullable();
+            $table->foreign('first_model_id')->references('id')->on('first_models');
+        });
+
         $this->app['db']->connection()->getSchemaBuilder()->create('second_model_third_model', function (Blueprint $table) {
             $table->integer('second_model_id');
             $table->integer('third_model_id');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,14 +42,18 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('name');
             $table->integer('second_model_id')->nullable();
+            $table->boolean('isAdmin')->default(false);
             $table->foreign('second_model_id')->references('id')->on('second_models');
         });
 
         $this->app['db']->connection()->getSchemaBuilder()->create('sixth_models', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->boolean('isAdmin')->default(false);
             $table->integer('first_model_id')->nullable();
             $table->foreign('first_model_id')->references('id')->on('first_models');
+            $table->timestamps();
+            $table->softDeletes();
         });
 
         $this->app['db']->connection()->getSchemaBuilder()->create('second_model_third_model', function (Blueprint $table) {

--- a/tests/TestModels/FifthModel.php
+++ b/tests/TestModels/FifthModel.php
@@ -12,6 +12,8 @@ class FifthModel extends Model
 
     protected $fillable = ['id', 'name', 'second_model_id'];
 
+    protected $guarded = ['isAdmin'];
+
     public $timestamps = false;
 
     protected static function newFactory()

--- a/tests/TestModels/FifthModel.php
+++ b/tests/TestModels/FifthModel.php
@@ -12,7 +12,7 @@ class FifthModel extends Model
 
     protected $fillable = ['id', 'name', 'second_model_id'];
 
-    protected $guarded = ['isAdmin'];
+    protected $guarded = ['is_admin'];
 
     public $timestamps = false;
 

--- a/tests/TestModels/FirstModel.php
+++ b/tests/TestModels/FirstModel.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class FirstModel extends Model
 {
@@ -25,6 +26,11 @@ class FirstModel extends Model
     public function fifth_models(): HasManyThrough
     {
         return $this->hasManyThrough(FifthModel::class, SecondModel::class, 'first_model_id', 'second_model_id');
+    }
+
+    public function sixth_model(): HasOne
+    {
+        return $this->hasOne(SixthModel::class, 'first_model_id', 'id');
     }
 
     protected static function newFactory()

--- a/tests/TestModels/SixthModel.php
+++ b/tests/TestModels/SixthModel.php
@@ -1,13 +1,13 @@
 <?php
 
 namespace CodencoDev\EloquentModelTester\Tests\TestModels;
-use Database\Factories\SixthModelFactory;
 
+use Database\Factories\SixthModelFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class SixthModel extends Model
 {

--- a/tests/TestModels/SixthModel.php
+++ b/tests/TestModels/SixthModel.php
@@ -14,9 +14,9 @@ class SixthModel extends Model
     use HasFactory;
     use SoftDeletes;
 
-    protected $fillable = ['id', 'name', 'isAdmin'];
+    protected $fillable = ['id', 'name', 'first_model_id', 'is_admin'];
 
-    protected $guarded = ['isAdmin'];
+    protected $guarded = ['is_admin'];
 
     public $timestamps = true;
 

--- a/tests/TestModels/SixthModel.php
+++ b/tests/TestModels/SixthModel.php
@@ -2,22 +2,24 @@
 
 namespace CodencoDev\EloquentModelTester\Tests\TestModels;
 
-use Database\Factories\FifthModelFactory;
+use Database\Factories\SixthModelFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
-class FifthModel extends Model
+class SixthModel extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
-    protected $fillable = ['id', 'name', 'second_model_id'];
+    protected $fillable = ['id', 'name', 'isAdmin'];
 
     protected $guarded = ['isAdmin'];
 
-    public $timestamps = false;
+    public $timestamps = true;
 
     protected static function newFactory()
     {
-        return FifthModelFactory::new();
+        return SixthModelFactory::new();
     }
 }

--- a/tests/TestModels/SixthModel.php
+++ b/tests/TestModels/SixthModel.php
@@ -1,20 +1,29 @@
 <?php
 
 namespace CodencoDev\EloquentModelTester\Tests\TestModels;
-
 use Database\Factories\SixthModelFactory;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 class SixthModel extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
-    public $timestamps = false;
+    protected $fillable = ['id', 'name', 'isAdmin'];
 
-    protected $fillable = ['id', 'name', 'first_model_id'];
+    protected $guarded = ['isAdmin'];
+
+    public $timestamps = true;
+
+    protected static function newFactory()
+    {
+        return SixthModelFactory::new();
+    }
 
     public function first_model(): BelongsTo
     {
@@ -24,10 +33,5 @@ class SixthModel extends Model
     public function morphed(): MorphOne
     {
         return $this->morphOne(MorphModel::class, 'morph_modelable');
-    }
-
-    protected static function newFactory()
-    {
-        return SixthModelFactory::new();
     }
 }

--- a/tests/TestModels/SixthModel.php
+++ b/tests/TestModels/SixthModel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CodencoDev\EloquentModelTester\Tests\TestModels;
+
+use Database\Factories\SixthModelFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class SixthModel extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = ['id', 'name', 'first_model_id'];
+
+    public function first_model(): BelongsTo
+    {
+        return $this->belongsTo(FirstModel::class, 'first_model_id', 'id');
+    }
+
+    public function morphed(): MorphOne
+    {
+        return $this->morphOne(MorphModel::class, 'morph_modelable');
+    }
+
+    protected static function newFactory()
+    {
+        return SixthModelFactory::new();
+    }
+}


### PR DESCRIPTION
Further to the discussion in Issue #15 these are the adjustments to the assertions.

1. `assertHasOnlyColumns()` - this is a strict check that the columns in the table match exactly to the expected values.
2. `assertCanOnlyFill()` - this is a strict check that only the fields that are passed can be filled.
3. `assertCanFillables()` - this is now an alias to `assertHasColumnsInFillable()`.
4. `assertHasColumnsInFillable()` - this is the original `assertCanFillables()` function renamed.
5. `assertHasOnlyColumnsInFillable()` - this is a strict check that the `$fillables` array matches the expected values.
6. `assertHasColumnsInGuarded()` - this checks to see if the expected fields are guarded.
7. `assertHasOnlyColumnsInGuarded()` - this is a strict check that the `$guarded` array matches the expected values.
8. `assertHasNoGuardedAndFillableFields()` - this checks to see if any fields appear in both the `$guarded` and `$fillable` arrays.

I've updated the test suite to try and test all these and their negatives.

I've update the README to list all the assertions - @thomasdominic could you check that you're happy with the descriptions of the relationship ones as well?