### PR TITLE
🔌 Use the model connection for the Schema checks

### DIFF
--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -17,18 +17,10 @@ class ModelTester extends TestCase
 
     private ?string $table;
 
-    private Schema $schema;
-
     public function create(?string $tested, ?string $table = null): self
     {
         $this->tested = $tested;
         $this->table = $table;
-
-        $this->schema = new Schema();
-
-        if ($this->tested && $this->isModelClass()) {
-            $this->schema::setConnection($this->getModelConnection());
-        }
 
         return $this;
     }
@@ -66,9 +58,12 @@ class ModelTester extends TestCase
 
     public function getModelConnection(): \Illuminate\Database\Connection
     {
-        $modelClass = $this->getModel();
+        if($this->tested && $this->isModelClass()) {
+            $modelClass = $this->getModel();
+            return (new $modelClass)->getConnection();
+        }
 
-        return (new $modelClass)->getConnection();
+        return Schema::getConnection();
     }
 
     public function isModelClass(?string $modelClass = null): bool
@@ -83,9 +78,9 @@ class ModelTester extends TestCase
     public function isExistingTable(?string $tableName = null): bool
     {
         if (! is_null($tableName)) {
-            return $this->schema::hasTable($tableName);
+            return Schema::setConnection($this->getModelConnection())->hasTable($tableName);
         } else {
-            return $this->schema::hasTable($this->getModelTable());
+            return Schema::setConnection($this->getModelConnection())->hasTable($this->getModelTable());
         }
     }
 
@@ -104,7 +99,7 @@ class ModelTester extends TestCase
         $columns = $this->getArrayParameters(...$columns);
         collect($columns)->each(function ($column) {
             $this->assertTrue(
-                in_array($column, $this->schema::getColumnListing($this->getTable())),
+                in_array($column, Schema::setConnection($this->getModelConnection())->getColumnListing($this->getTable())),
                 sprintf(
                     'Column %s isn\'t a column of table %s.',
                     $column,
@@ -119,7 +114,7 @@ class ModelTester extends TestCase
     public function assertHasOnlyColumns(array|string ...$columns): self
     {
         $columns = $this->getArrayParameters(...$columns);
-        $this->assertEqualsCanonicalizing($columns, $this->schema::getColumnListing($this->getTable()), 'The columns of the database table do not match the expected values.');
+        $this->assertEqualsCanonicalizing($columns, Schema::setConnection($this->getModelConnection())->getColumnListing($this->getTable()), 'The columns of the database table do not match the expected values.');
 
         return $this;
     }

--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -58,7 +58,7 @@ class ModelTester extends TestCase
 
     public function getModelConnection(): \Illuminate\Database\Connection
     {
-        if($this->tested && $this->isModelClass()) {
+        if ($this->tested && $this->isModelClass()) {
             $modelClass = $this->getModel();
             return (new $modelClass)->getConnection();
         }


### PR DESCRIPTION
For certain setups, models have a different connection set directly on the model by overloading the `getConnectionName()`. Examples of this would be [spatie/laravel-multitenancy](https://github.com/spatie/laravel-multitenancy/tree/main).

When this is the case, the tests will fail as the connection is not the "default".

This PR determines makes use of the model's `getConnection()` method and sets this on the `Schema` directly. Then the correct connection is used.

There is a check in the `getModelConnection()` method to ensure that a model is present and that it is a suitable model class.

I don't think that this is a breaking change as the tests all pass.  However, as this uses the model connection now, it could be worth a second set of eyes looking over it to make sure that there aren't any fringe cases that aren't obvious.