### PR TITLE
🧪 Extend the `Assert` class instead of `TestCase`

### DIFF
--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -9,9 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Assert;
 
-class ModelTester extends TestCase
+class ModelTester extends Assert
 {
     private ?string $tested;
 


### PR DESCRIPTION
While trying to upgrade to PEST v2.0 I was encountering the following error:

```
Unresolvable dependency resolving [Parameter #0 [ $name ]] in PHPUnit\Framework\TestCase
```

From what I can tell, at some point PHPUnit updated the `__construct()` function to require a name to be present. This was not resolvable by the dependency injector.

That being said, I don't think that the package _should_ be extending the `TestCase`, as it is not a test, but more an assertion extension. As such this pull request moves the package to extend the `Assert` class which still retains the ability to test, but fits better with what the package is trying to achieve.

I've rerun the test suite with the alteration and have no errors being produced. As far as I can tell this is still backward compatible, as in essence the package was only ever using the `Assert` part of `TestCase` anyway.