### PR TITLE
🔧 Use the `getMorphClass()` method

### DIFF
--- a/src/ModelTester.php
+++ b/src/ModelTester.php
@@ -440,7 +440,7 @@ class ModelTester extends Assert
         $instance = $related::factory()->create();
         $morph = $this->getModel()::factory()->create([
             $id => $instance->id,
-            $type => $related,
+            $type => $instance->getMorphClass(),
         ]);
         $morph->refresh();
 


### PR DESCRIPTION
If a user has implemented the `Relation::enforceMorphMap()` feature of Laravel, then the classname is being mapped. This PR adjusts the `assertHasBelongsToMorphRelation()` check to use the `getMorphClass()` on the `$instance` thereby applying the mapping as per the morph map.